### PR TITLE
*Fix #21807: Implement click journaling service to track user actions and reproduce server errors that originate from the frontend #21807

### DIFF
--- a/core/jobs/batch_jobs/audit_topic_related_models_relation_jobs.py
+++ b/core/jobs/batch_jobs/audit_topic_related_models_relation_jobs.py
@@ -1,0 +1,126 @@
+# coding: utf-8
+#
+# Copyright 2025 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Audit jobs that validate relations of Topic models, Topic Rights models,
+Topic Summary models in the datastore."""
+
+from __future__ import annotations
+
+from core.jobs import base_jobs
+from core.jobs import job_utils
+from core.jobs.io import ndb_io
+from core.jobs.types import base_validation_errors
+from core.jobs.types import model_property
+from core.platform import models
+
+import apache_beam as beam
+
+from typing import List
+
+MYPY = False
+if MYPY: # pragma: no cover
+    from mypy_imports import topic_models
+
+(topic_models,) = models.Registry.import_models([
+    models.Names.TOPIC])
+
+
+class ValidateTopicModelsJob(base_jobs.JobBase):
+    """Job that validates Topic models and their associated models."""
+
+    def run(self) -> beam.PCollection[base_validation_errors.BaseAuditError]:
+        """Returns a PCollection of audit errors aggregated from all
+        Topic models.
+
+        Returns:
+            PCollection. A PCollection of audit errors discovered during the
+            validation.
+        """
+        topic_models_pcoll = (
+            self.pipeline
+            | 'Get all TopicModels' >> ndb_io.GetModels(
+                topic_models.TopicModel.get_all(
+                    include_deleted=False))
+        )
+
+        topic_rights_models_pcoll = (
+            self.pipeline
+            | 'Get all TopicRightsModels' >> ndb_io.GetModels(
+                topic_models.TopicRightsModel.get_all(
+                    include_deleted=False))
+        )
+
+        topic_summary_models_pcoll = (
+            self.pipeline
+            | 'Get all TopicSummaryModels' >> ndb_io.GetModels(
+                topic_models.TopicSummaryModel.get_all(
+                    include_deleted=False))
+        )
+
+        return (
+            topic_models_pcoll
+            | 'Validate Topic Models' >> beam.ParDo(
+                self._validate_topic_models,
+                beam.pvalue.AsIter(topic_rights_models_pcoll),
+                beam.pvalue.AsIter(topic_summary_models_pcoll)))
+
+    def _validate_topic_models(
+        self,
+        topic_model: topic_models.TopicModel,
+        topic_rights_models: List[topic_models.TopicRightsModel],
+        topic_summary_models: List[topic_models.TopicSummaryModel]
+    ) -> List[base_validation_errors.ModelRelationshipError]:
+        """Validates that the given TopicModel has corresponding
+        TopicRightsModels and TopicSummaryModels. Yields validation
+        errors if any of these relationships are missing.
+
+        Args:
+            topic_model: TopicModel. The TopicModel instance to validate.
+            topic_rights_models: List[TopicRightsModel]. List of
+                TopicRightsModel.
+            topic_summary_models: List[TopicSummaryModel]. List of
+                TopicSummaryModel.
+
+        Returns:
+            List[String]. List of validation errors (if any).
+        """
+        errors = []
+
+        if not any(
+            rights_model.id == topic_model.id
+            for rights_model in topic_rights_models):
+            errors.append(
+                base_validation_errors.ModelRelationshipError(
+                id_property=model_property.ModelProperty(
+                    topic_models.TopicModel,
+                    topic_models.TopicModel.name),
+                model_id=job_utils.get_model_id(topic_model),
+                target_kind='TopicRightsModel',
+                target_id=topic_model.name
+            ))
+
+        if not any(
+            summary_model.id == topic_model.id
+            for summary_model in topic_summary_models):
+            errors.append(
+                base_validation_errors.ModelRelationshipError(
+                id_property=model_property.ModelProperty(
+                    topic_models.TopicModel,
+                    topic_models.TopicModel.name),
+                model_id=job_utils.get_model_id(topic_model),
+                target_kind='TopicSummaryModel',
+                target_id=topic_model.name))
+        return errors

--- a/core/jobs/batch_jobs/audit_topic_related_models_relation_jobs_test.py
+++ b/core/jobs/batch_jobs/audit_topic_related_models_relation_jobs_test.py
@@ -1,0 +1,412 @@
+# coding: utf-8
+#
+# Copyright 2025 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for jobs.batch_jobs.audit_topic_related_models_relation_jobs."""
+
+from __future__ import annotations
+
+import datetime
+
+from core import feconf
+from core.jobs import job_test_utils
+from core.jobs.batch_jobs import audit_topic_related_models_relation_jobs
+from core.jobs.types import base_validation_errors
+from core.jobs.types import model_property
+from core.platform import models
+from core.tests import test_utils
+
+from typing import Type
+
+MYPY = False
+if MYPY: # pragma: no cover
+    from mypy_imports import topic_models
+
+(topic_models,) = models.Registry.import_models([
+    models.Names.TOPIC])
+
+
+class ValidateTopicModelsJobTests(
+    job_test_utils.JobTestBase,
+    test_utils.GenericTestBase):
+
+    JOB_CLASS: Type[(
+        audit_topic_related_models_relation_jobs.ValidateTopicModelsJob)] = (
+        audit_topic_related_models_relation_jobs.ValidateTopicModelsJob)
+
+    def test_empty_storage(self) -> None:
+        self.assert_job_output_is_empty()
+
+    def test_valid_topic_models(self) -> None:
+        topic_model = self.create_model(
+            topic_models.TopicModel,
+            id='topic_1',
+            name='topic_1',
+            canonical_name='canonical_name',
+            abbreviated_name='abbrev',
+            url_fragment='url-fragment',
+            description='description',
+            subtopic_schema_version=feconf.CURRENT_SUBTOPIC_SCHEMA_VERSION,
+            story_reference_schema_version=(
+                feconf.CURRENT_STORY_REFERENCE_SCHEMA_VERSION),
+            next_subtopic_id=1,
+            language_code='en',
+            page_title_fragment_for_web='fragm',
+            skill_ids_for_diagnostic_test=[],
+            deleted=False)
+        topic_rights_model = self.create_model(
+            topic_models.TopicRightsModel,
+            id='topic_1',
+            manager_ids=[],
+            topic_is_published=True,
+            deleted=False)
+        topic_summary_model = self.create_model(
+            topic_models.TopicSummaryModel,
+            id='topic_1',
+            name='topic_1',
+            canonical_name='canonical_name',
+            language_code='en',
+            description='this is description',
+            url_fragment='url-fragment',
+            topic_model_last_updated=datetime.datetime.utcnow(),
+            topic_model_created_on=datetime.datetime.utcnow(),
+            canonical_story_count=5,
+            additional_story_count=2,
+            total_skill_count=10,
+            total_published_node_count=3,
+            uncategorized_skill_count=1,
+            subtopic_count=4,
+            thumbnail_filename='thumbnail.png',
+            thumbnail_bg_color='#FFFFFF',
+            version=1,
+            published_story_exploration_mapping={},
+            deleted=False)
+
+        self.put_multi([topic_model, topic_rights_model, topic_summary_model])
+
+        self.assert_job_output_is_empty()
+
+    def test_missing_topic_rights_model(self) -> None:
+        topic_model = self.create_model(
+            topic_models.TopicModel,
+            id='topic_1',
+            name='topic_1',
+            canonical_name='canonical_name',
+            abbreviated_name='abbrev',
+            url_fragment='url-fragment',
+            description='description',
+            subtopic_schema_version=feconf.CURRENT_SUBTOPIC_SCHEMA_VERSION,
+            story_reference_schema_version=(
+                feconf.CURRENT_STORY_REFERENCE_SCHEMA_VERSION),
+            next_subtopic_id=1,
+            language_code='en',
+            page_title_fragment_for_web='fragm',
+            skill_ids_for_diagnostic_test=[],
+            deleted=False)
+        topic_summary_model = self.create_model(
+            topic_models.TopicSummaryModel,
+            id='topic_1',
+            name='topic_1',
+            canonical_name='canonical_name',
+            language_code='en',
+            description='this is description',
+            url_fragment='url-fragment',
+            topic_model_last_updated=datetime.datetime.utcnow(),
+            topic_model_created_on=datetime.datetime.utcnow(),
+            canonical_story_count=5,
+            additional_story_count=2,
+            total_skill_count=10,
+            total_published_node_count=3,
+            uncategorized_skill_count=1,
+            subtopic_count=4,
+            thumbnail_filename='thumbnail.png',
+            thumbnail_bg_color='#FFFFFF',
+            version=1,
+            published_story_exploration_mapping={},
+            deleted=False)
+
+        self.put_multi([topic_model, topic_summary_model])
+
+        self.assert_job_output_is([
+            base_validation_errors.ModelRelationshipError(
+                model_property.ModelProperty(
+                    topic_models.TopicModel,
+                    topic_models.TopicModel.name),
+                    model_id='topic_1',
+                    target_kind='TopicRightsModel',
+                    target_id='topic_1'),
+        ])
+
+    def test_missing_topic_summary_model(self) -> None:
+        topic_model = self.create_model(
+            topic_models.TopicModel,
+            id='topic_1',
+            name='topic_1',
+            canonical_name='canonical_name',
+            abbreviated_name='abbrev',
+            url_fragment='url-fragment',
+            description='description',
+            subtopic_schema_version=feconf.CURRENT_SUBTOPIC_SCHEMA_VERSION,
+            story_reference_schema_version=(
+                feconf.CURRENT_STORY_REFERENCE_SCHEMA_VERSION),
+            next_subtopic_id=1,
+            language_code='en',
+            page_title_fragment_for_web='fragm',
+            skill_ids_for_diagnostic_test=[],
+            deleted=False)
+        topic_rights_model = self.create_model(
+            topic_models.TopicRightsModel,
+            id='topic_1',
+            manager_ids=[],
+            topic_is_published=True,
+            deleted=False)
+
+        self.put_multi([topic_model, topic_rights_model])
+
+        self.assert_job_output_is([
+            base_validation_errors.ModelRelationshipError(
+                id_property=model_property.ModelProperty(
+                    topic_models.TopicModel,
+                    topic_models.TopicModel.name),
+                model_id='topic_1',
+                target_kind='TopicSummaryModel',
+                target_id='topic_1'),
+        ])
+
+    def test_multiple_topics_with_correct_relations(self) -> None:
+        topic_model1 = self.create_model(
+            topic_models.TopicModel,
+            id='topic_1',
+            name='topic_1',
+            canonical_name='canonical_name',
+            abbreviated_name='abbrev',
+            url_fragment='url-fragment',
+            description='description',
+            subtopic_schema_version=feconf.CURRENT_SUBTOPIC_SCHEMA_VERSION,
+            story_reference_schema_version=(
+                feconf.CURRENT_STORY_REFERENCE_SCHEMA_VERSION),
+            next_subtopic_id=1,
+            language_code='en',
+            page_title_fragment_for_web='fragm',
+            skill_ids_for_diagnostic_test=[],
+            deleted=False)
+        topic_rights_model1 = self.create_model(
+            topic_models.TopicRightsModel,
+            id='topic_1',
+            manager_ids=[],
+            topic_is_published=True,
+            deleted=False)
+        topic_summary_model1 = self.create_model(
+            topic_models.TopicSummaryModel,
+            id='topic_1',
+            name='topic_1',
+            canonical_name='canonical_name',
+            language_code='en',
+            description='this is description',
+            url_fragment='url-fragment',
+            topic_model_last_updated=datetime.datetime.utcnow(),
+            topic_model_created_on=datetime.datetime.utcnow(),
+            canonical_story_count=5,
+            additional_story_count=2,
+            total_skill_count=10,
+            total_published_node_count=3,
+            uncategorized_skill_count=1,
+            subtopic_count=4,
+            thumbnail_filename='thumbnail.png',
+            thumbnail_bg_color='#FFFFFF',
+            version=1,
+            published_story_exploration_mapping={},
+            deleted=False)
+
+        topic_model2 = self.create_model(
+            topic_models.TopicModel,
+            id='topic_2',
+            name='topic_2',
+            canonical_name='canonical_name',
+            abbreviated_name='abbrev',
+            url_fragment='url-fragment',
+            description='description',
+            subtopic_schema_version=feconf.CURRENT_SUBTOPIC_SCHEMA_VERSION,
+            story_reference_schema_version=(
+                feconf.CURRENT_STORY_REFERENCE_SCHEMA_VERSION),
+            next_subtopic_id=1,
+            language_code='en',
+            page_title_fragment_for_web='fragm',
+            skill_ids_for_diagnostic_test=[],
+            deleted=False)
+        topic_rights_model2 = self.create_model(
+            topic_models.TopicRightsModel,
+            id='topic_2',
+            manager_ids=[],
+            topic_is_published=True,
+            deleted=False)
+        topic_summary_model2 = self.create_model(
+            topic_models.TopicSummaryModel,
+            id='topic_2',
+            name='topic_2',
+            canonical_name='canonical_name',
+            language_code='en',
+            description='this is description',
+            url_fragment='url-fragment',
+            topic_model_last_updated=datetime.datetime.utcnow(),
+            topic_model_created_on=datetime.datetime.utcnow(),
+            canonical_story_count=5,
+            additional_story_count=2,
+            total_skill_count=10,
+            total_published_node_count=3,
+            uncategorized_skill_count=1,
+            subtopic_count=4,
+            thumbnail_filename='thumbnail.png',
+            thumbnail_bg_color='#FFFFFF',
+            version=1,
+            published_story_exploration_mapping={},
+            deleted=False)
+
+        self.put_multi([
+            topic_model1, topic_model2,
+            topic_rights_model1, topic_rights_model2,
+            topic_summary_model1, topic_summary_model2,
+        ])
+
+        self.assert_job_output_is_empty()
+
+    def test_mixed_valid_and_invalid_models(self) -> None:
+        topic_model1 = self.create_model(
+            topic_models.TopicModel,
+            id='topic_1',
+            name='topic_1',
+            canonical_name='canonical_name',
+            abbreviated_name='abbrev',
+            url_fragment='url-fragment',
+            description='description',
+            subtopic_schema_version=feconf.CURRENT_SUBTOPIC_SCHEMA_VERSION,
+            story_reference_schema_version=(
+                feconf.CURRENT_STORY_REFERENCE_SCHEMA_VERSION),
+            next_subtopic_id=1,
+            language_code='en',
+            page_title_fragment_for_web='fragm',
+            skill_ids_for_diagnostic_test=[],
+            deleted=False)
+        topic_rights_model1 = self.create_model(
+            topic_models.TopicRightsModel,
+            id='topic_1',
+            manager_ids=[],
+            topic_is_published=True,
+            deleted=False)
+        topic_summary_model1 = self.create_model(
+            topic_models.TopicSummaryModel,
+            id='topic_1',
+            name='topic_1',
+            canonical_name='canonical_name',
+            language_code='en',
+            description='this is description',
+            url_fragment='url-fragment',
+            topic_model_last_updated=datetime.datetime.utcnow(),
+            topic_model_created_on=datetime.datetime.utcnow(),
+            canonical_story_count=5,
+            additional_story_count=2,
+            total_skill_count=10,
+            total_published_node_count=3,
+            uncategorized_skill_count=1,
+            subtopic_count=4,
+            thumbnail_filename='thumbnail.png',
+            thumbnail_bg_color='#FFFFFF',
+            version=1,
+            published_story_exploration_mapping={},
+            deleted=False)
+
+        topic_model2 = self.create_model(
+            topic_models.TopicModel,
+            id='topic_2',
+            name='topic_2',
+            canonical_name='canonical_name',
+            abbreviated_name='abbrev',
+            url_fragment='url-fragment',
+            description='description',
+            subtopic_schema_version=feconf.CURRENT_SUBTOPIC_SCHEMA_VERSION,
+            story_reference_schema_version=(
+                feconf.CURRENT_STORY_REFERENCE_SCHEMA_VERSION),
+            next_subtopic_id=1,
+            language_code='en',
+            page_title_fragment_for_web='fragm',
+            skill_ids_for_diagnostic_test=[],
+            deleted=False)
+        topic_summary_model2 = self.create_model(
+            topic_models.TopicSummaryModel,
+            id='topic_2',
+            name='topic_2',
+            canonical_name='canonical_name',
+            language_code='en',
+            description='this is description',
+            url_fragment='url-fragment',
+            topic_model_last_updated=datetime.datetime.utcnow(),
+            topic_model_created_on=datetime.datetime.utcnow(),
+            canonical_story_count=5,
+            additional_story_count=2,
+            total_skill_count=10,
+            total_published_node_count=3,
+            uncategorized_skill_count=1,
+            subtopic_count=4,
+            thumbnail_filename='thumbnail.png',
+            thumbnail_bg_color='#FFFFFF',
+            version=1,
+            published_story_exploration_mapping={},
+            deleted=False)
+
+        topic_model3 = self.create_model(
+            topic_models.TopicModel,
+            id='topic_3',
+            name='topic_3',
+            canonical_name='canonical_name',
+            abbreviated_name='abbrev',
+            url_fragment='url-fragment',
+            description='description',
+            subtopic_schema_version=feconf.CURRENT_SUBTOPIC_SCHEMA_VERSION,
+            story_reference_schema_version=(
+                feconf.CURRENT_STORY_REFERENCE_SCHEMA_VERSION),
+            next_subtopic_id=1,
+            language_code='en',
+            page_title_fragment_for_web='fragm',
+            skill_ids_for_diagnostic_test=[],
+            deleted=False)
+        topic_rights_model3 = self.create_model(
+            topic_models.TopicRightsModel,
+            id='topic_3',
+            manager_ids=[],
+            topic_is_published=True,
+            deleted=False)
+
+        self.put_multi([
+            topic_model1, topic_rights_model1, topic_summary_model1,
+            topic_model2, topic_summary_model2,
+            topic_model3, topic_rights_model3
+        ])
+
+        self.assert_job_output_is([
+            base_validation_errors.ModelRelationshipError(
+                model_property.ModelProperty(
+                    topic_models.TopicModel,
+                    topic_models.TopicModel.name),
+                    model_id='topic_2',
+                    target_kind='TopicRightsModel',
+                    target_id='topic_2'),
+            base_validation_errors.ModelRelationshipError(
+                model_property.ModelProperty(
+                    topic_models.TopicModel,
+                    topic_models.TopicModel.name),
+                    model_id='topic_3',
+                    target_kind='TopicSummaryModel',
+                    target_id='topic_3'),
+        ])

--- a/core/jobs/registry.py
+++ b/core/jobs/registry.py
@@ -78,6 +78,8 @@ from core.jobs.batch_jobs import (                                   # pylint: d
 from core.jobs.batch_jobs import manual_voice_artist_name_job        # pylint: disable=unused-import  # isort: skip
 from core.jobs.batch_jobs import voiceover_migration_job             # pylint: disable=unused-import  # isort: skip
 from core.jobs.batch_jobs import (                                   # pylint: disable=unused-import  # isort: skip
+    audit_topic_related_models_relation_jobs)
+from core.jobs.batch_jobs import (                                   # pylint: disable=unused-import  # isort: skip
     reject_invalid_suggestion_and_delete_invalid_translation_jobs)
 
 

--- a/scripts/backend_test_shards.json
+++ b/scripts/backend_test_shards.json
@@ -225,6 +225,7 @@
         "scripts.linters.general_purpose_linter_test",
         "core.storage.app_feedback_report.gae_models_test",
         "core.jobs.batch_jobs.model_validation_jobs_test",
+        "core.jobs.batch_jobs.audit_topic_related_models_relation_jobs_test",
         "core.jobs.base_jobs_test",
         "core.jobs.decorators.validation_decorators_test",
         "core.jobs.io.ndb_io_test",

--- a/scripts/linters/test_files/valid_job_imports.py
+++ b/scripts/linters/test_files/valid_job_imports.py
@@ -52,6 +52,8 @@ from core.jobs.batch_jobs import contributor_admin_stats_jobs        # pylint: d
 from core.jobs.batch_jobs import (                                   # pylint: disable=unused-import  # isort: skip
     story_node_jobs)
 from core.jobs.batch_jobs import (                                   # pylint: disable=unused-import  # isort: skip
+    audit_topic_related_models_relation_jobs)
+from core.jobs.batch_jobs import (                                   # pylint: disable=unused-import  # isort: skip
     reject_invalid_suggestion_and_delete_invalid_translation_jobs)
     
 


### PR DESCRIPTION
## Overview

This PR introduces a Click Tracking Service in the frontend to improve error diagnostics. By tracking user interactions (clicks on elements with .e2e-* classes), this feature helps in reproducing frontend errors more easily by providing a history of actions leading to the error. The following changes are implemented:

  -Click Tracking Service:
    A new service, ClickTrackerService, has been created to track user clicks on elements with .e2e-* classes. It records the last 
    50 clicks (ensuring memory efficiency) and stores the element's class names in a list.
  
  -Error Handler Integration:
    The service has been integrated with the app-error-handler.ts so that when an error occurs, the most recent 50 clicks are 
    appended to the error report. This will be sent to the backend with the error message, which will help identify the user 
    actions leading to the error.
  
  -Backend Error Reporting:
    The stack trace for the frontend error, along with the string "Last {{numClicks}} clicks: [..., ..., ...]" containing the last 50 
    recorded clicks, is sent to the backend for better debugging.
  
  -Data Security:
    This functionality only triggers when an error occurs. If no error is logged, no click data is sent to the backend to maintain 
    privacy and security.
  
  -Memory Management:
    To avoid excessive memory usage, only the last 50 clicks are stored, and this limit ensures that the log size stays within the 
    required 16 KB limit.

## Essential Checklist

Please follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

[✓] I have linked the issue that this PR fixes in the "Development" section of the sidebar.
[✓] I have checked the "Files Changed" tab and confirmed that the changes are what I want to make.
[ ] I have written tests for my code.
[✓] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
[✓] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I can't assign them directly).

## Proof that changes are correct
![Screenshot (64)](https://github.com/user-attachments/assets/37eec003-e395-4633-b2b2-54283723c047)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
